### PR TITLE
Merge feature/typed routes

### DIFF
--- a/app-shared/src/commonMain/kotlin/PaintedDogsApp.kt
+++ b/app-shared/src/commonMain/kotlin/PaintedDogsApp.kt
@@ -17,14 +17,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import org.pointyware.painteddogs.core.entities.Uuid
-import org.pointyware.painteddogs.core.navigation.LocationRoot
-import org.pointyware.painteddogs.core.navigation.route
+import org.pointyware.painteddogs.core.navigation.TypeRouter
 import org.pointyware.painteddogs.core.ui.design.PaintedDogsTheme
-import org.pointyware.painteddogs.feature.funds.navigation.fundsRoute
+import org.pointyware.painteddogs.feature.funds.navigation.Funds
 import org.pointyware.painteddogs.feature.funds.navigation.fundsRouting
+import org.pointyware.painteddogs.feature.profiles.navigation.Profile
 import org.pointyware.painteddogs.feature.profiles.navigation.profileRouting
 import org.pointyware.painteddogs.shared.di.AppDependencies
-import org.pointyware.painteddogs.shared.home.homeRoute
+import org.pointyware.painteddogs.shared.home.Home
 import org.pointyware.painteddogs.shared.home.homeRouting
 
 /**
@@ -63,14 +63,15 @@ fun PaintedDogsApp(
                         }
                     },
                     title = {
-                        Text(currentLocation.value.segments.lastOrNull() ?: "Painted Dogs")
+                        Text(currentLocation.value.simpleName ?: "Painted Dogs")
                     },
                     actions = {
                         val userId: Uuid = Uuid.v4() // TODO: get actual user/id from active user
-                        IconButton(onClick = { navController.navigateTo(route("users", userId.toString(), "profile")) }) {
+                        IconButton(onClick = {
+                            navController.navigateTo(Profile::class, Profile(userId)) }) {
                             Icon(Icons.Default.AccountBox, contentDescription = "Profile")
                         }
-                        IconButton(onClick = { navController.navigateTo(route("funds", "search")) }) {
+                        IconButton(onClick = { navController.navigateTo(Funds.Search::class, Funds.Search) }) {
                             Icon(Icons.Default.Search, contentDescription = "Search")
                         }
                     },
@@ -78,14 +79,12 @@ fun PaintedDogsApp(
             },
             floatingActionButton = {
                 when (currentLocation.value) {
-                    homeRoute,
-                    fundsRoute -> {
+                    Home::class,
+                    Funds::class -> {
                         IconButton(onClick = {
                             navController.navigateTo(
-                                route(
-                                    "funds",
-                                    "create"
-                                )
+                                Funds.Create::class,
+                                Funds.Create
                             )
                         }) {
                             Icon(Icons.Default.AddCircle, contentDescription = "Create Fund")
@@ -120,7 +119,7 @@ fun PaintedDogsApp(
 //                }
 //            }
         ) { paddingValues ->
-            LocationRoot(
+            TypeRouter(
                 navController = navController,
                 modifier = Modifier.padding(paddingValues),
             ) {

--- a/app-shared/src/commonMain/kotlin/di/HomeModule.kt
+++ b/app-shared/src/commonMain/kotlin/di/HomeModule.kt
@@ -1,9 +1,12 @@
 package org.pointyware.painteddogs.shared.di
 
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.pointyware.painteddogs.shared.home.Home
 import org.pointyware.painteddogs.shared.home.HomeUiStateMapper
 import org.pointyware.painteddogs.shared.home.HomeViewModel
 import org.pointyware.painteddogs.shared.home.HomeViewModelImpl
+import kotlin.reflect.KClass
 
 /**
  * Defines productions bindings to satisfy interface requests.
@@ -13,4 +16,5 @@ fun homeModule() = module {
 
     single<HomeUiStateMapper> { HomeUiStateMapper }
     single<HomeViewModel> { HomeViewModelImpl() }
+    single<KClass<*>>(qualifier = named("Home")) { Home::class}
 }

--- a/app-shared/src/commonMain/kotlin/home/HomeRouting.kt
+++ b/app-shared/src/commonMain/kotlin/home/HomeRouting.kt
@@ -4,27 +4,30 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import org.koin.mp.KoinPlatform.getKoin
-import org.pointyware.painteddogs.core.navigation.LocationRootScope
-import org.pointyware.painteddogs.core.navigation.Route
-import org.pointyware.painteddogs.core.navigation.route
+import org.pointyware.painteddogs.core.navigation.TypeRouterScope
+import org.pointyware.painteddogs.feature.funds.navigation.Funds
 import org.pointyware.painteddogs.shared.di.HomeDependencies
 
-val homeRoute = route<String>()
+object Home {}
+
 /**
  * Sets up all routes for home navigation.
  */
 @Composable
-fun LocationRootScope<Route<String>, Any>.homeRouting() {
+fun TypeRouterScope.homeRouting() {
     val di = remember { getKoin() }
     val profileDependencies = remember { di.get<HomeDependencies>() }
 
-    location(homeRoute) {
+    location(Home::class) { navController, _ ->
         val homeViewModel = remember { profileDependencies.getHomeViewModel() }
         val mapper = remember { profileDependencies.getHomeUiStateMapper() }
         val state = homeViewModel.state.collectAsState()
         HomeScreen(
             state = mapper.map(state.value),
-            onFundSelected = { collectionId -> it.navigateTo(route("funds", collectionId)) },
+            onFundSelected = { collectionId ->
+                val arg = Funds.FundDetails(collectionId)
+                navController.navigateTo(Funds.FundDetails::class, arg)
+            },
         )
     }
 }

--- a/app-shared/src/commonMain/kotlin/home/HomeScreen.kt
+++ b/app-shared/src/commonMain/kotlin/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import org.pointyware.painteddogs.core.entities.Uuid
 import org.pointyware.painteddogs.feature.funds.ui.FundRow
 import org.pointyware.painteddogs.feature.funds.ui.FundRowState
 
@@ -21,7 +22,7 @@ data class HomeScreenState(
 fun HomeScreen(
     state: HomeScreenState,
     modifier: Modifier = Modifier,
-    onFundSelected: (String) -> Unit,
+    onFundSelected: (Uuid) -> Unit,
 ) {
     Column(
         modifier = modifier

--- a/core/navigation/src/commonMain/kotlin/Route.kt
+++ b/core/navigation/src/commonMain/kotlin/Route.kt
@@ -1,0 +1,41 @@
+
+/**
+ * Supporting interface for LocationRootScope to allow type-safe or string paths with
+ * `LocationRootScope<Route<Any>, Any>` or `LocationRootScope<String, Any>`.
+ *
+ * ```kotlin
+ * class TypeA(val name: String): Segment.Static {
+ *   inner class TypeB(val name: String): Segment.Variable {
+ *
+ *   }
+ * }
+ * ```
+ *
+ * ```kotlin
+ * val route = TypeA("some").TypeB("userId")
+ * ```
+ */
+interface Route<S> {
+    val segments: List<S>
+}
+
+data class SegmentList<S>(override val segments: List<S>): Route<S> {
+    operator fun plus(segment: S): SegmentList<S> {
+        return SegmentList(segments + segment)
+    }
+}
+
+/**
+ * Replace `location("some/path") {` with `location(route("some", "path")) {`
+ */
+fun <S> route(vararg segments: S): Route<S> {
+    return SegmentList(segments.toList())
+}
+
+sealed interface Segment {
+    val name: String
+    data class Static(override val name: String): Segment
+    data class Variable(override val name: String): Segment
+}
+fun static(name: String): Segment = Segment.Static(name)
+fun variable(name: String): Segment = Segment.Variable(name)

--- a/core/navigation/src/commonMain/kotlin/di/NavigationDependencies.kt
+++ b/core/navigation/src/commonMain/kotlin/di/NavigationDependencies.kt
@@ -2,17 +2,15 @@ package org.pointyware.painteddogs.core.navigation.di
 
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
-import org.koin.core.parameter.parametersOf
-import org.pointyware.painteddogs.core.navigation.Route
 import org.pointyware.painteddogs.core.navigation.StackNavigationController
 
 /**
  *
  */
 interface NavigationDependencies {
-    fun getNavController(): StackNavigationController<Route<String>, Any>
+    fun getNavController(): StackNavigationController
 }
 
 class KoinNavigationDependencies: NavigationDependencies, KoinComponent {
-    override fun getNavController(): StackNavigationController<Route<String>, Any> = get()
+    override fun getNavController(): StackNavigationController = get()
 }

--- a/core/navigation/src/commonMain/kotlin/di/NavigationModule.kt
+++ b/core/navigation/src/commonMain/kotlin/di/NavigationModule.kt
@@ -1,11 +1,9 @@
 package org.pointyware.painteddogs.core.navigation.di
 
-import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import org.pointyware.painteddogs.core.navigation.Route
 import org.pointyware.painteddogs.core.navigation.StackNavigationController
 import org.pointyware.painteddogs.core.navigation.StackNavigationControllerImpl
-import org.pointyware.painteddogs.core.navigation.route
 
 /**
  *
@@ -13,7 +11,7 @@ import org.pointyware.painteddogs.core.navigation.route
 fun coreNavigationModule() = module {
     single<NavigationDependencies> { KoinNavigationDependencies() }
 
-    single<StackNavigationController<Route<String>, Any>> {
-        StackNavigationControllerImpl(route())
+    single<StackNavigationController> {
+        StackNavigationControllerImpl(get(qualifier = named("Home")))
     }
 }

--- a/feature/funds/src/commonMain/kotlin/di/FundsModule.kt
+++ b/feature/funds/src/commonMain/kotlin/di/FundsModule.kt
@@ -53,7 +53,7 @@ fun featureFundsViewModelsModule() = module {
     factory<FundSearchViewModel> { FundSearchViewModelImpl(get()) }
     factory<FundDetailsViewModel> {
         FundDetailsViewModelImpl(
-            navController = get<StackNavigationController<Route<String>, Any>>(),
+            navController = get<StackNavigationController>(),
             createFundUseCase = get()
         )
     }

--- a/feature/funds/src/commonMain/kotlin/ui/ContributionHistoryScreen.kt
+++ b/feature/funds/src/commonMain/kotlin/ui/ContributionHistoryScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import org.pointyware.painteddogs.core.entities.Uuid
 import org.pointyware.painteddogs.feature.funds.viewmodels.ContributionHistoryViewModel
 
 data class ContributionHistoryScreenState(
@@ -19,7 +20,7 @@ data class ContributionHistoryScreenState(
 fun ContributionHistoryScreen(
     state: ContributionHistoryScreenState,
     modifier: Modifier = Modifier,
-    onViewFund: (String) -> Unit
+    onViewFund: (Uuid) -> Unit
 ) {
     Column(
         modifier = modifier

--- a/feature/funds/src/commonMain/kotlin/ui/FundHistoryScreen.kt
+++ b/feature/funds/src/commonMain/kotlin/ui/FundHistoryScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import org.pointyware.painteddogs.core.entities.Uuid
 
 data class FundHistoryScreenState(
     val collections: List<FundRowState> = emptyList()
@@ -16,7 +17,7 @@ data class FundHistoryScreenState(
 fun FundHistoryScreen(
     state: FundHistoryScreenState,
     modifier: Modifier = Modifier,
-    onViewFund: (String) -> Unit
+    onViewFund: (Uuid) -> Unit
 ) {
     Column(
         modifier = modifier

--- a/feature/funds/src/commonMain/kotlin/ui/FundRowItem.kt
+++ b/feature/funds/src/commonMain/kotlin/ui/FundRowItem.kt
@@ -8,9 +8,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.pointyware.painteddogs.core.entities.Uuid
 
 data class FundRowState(
-    val fundId: String,
+    val fundId: Uuid,
     val title: String,
     val description: String,
 )
@@ -22,7 +23,7 @@ data class FundRowState(
 fun FundRow(
     state: FundRowState,
     modifier: Modifier = Modifier,
-    onTap: (String) -> Unit,
+    onTap: (Uuid) -> Unit,
 ) {
     Row(
         modifier = modifier

--- a/feature/funds/src/commonMain/kotlin/viewmodels/ContributionDetailsViewModel.kt
+++ b/feature/funds/src/commonMain/kotlin/viewmodels/ContributionDetailsViewModel.kt
@@ -8,10 +8,16 @@ import kotlinx.coroutines.flow.StateFlow
  */
 interface ContributionDetailsViewModel {
     val state: StateFlow<ContributionDetailsUiState>
+
+    fun onConfirm()
 }
 
 class ContributionDetailsViewModelImpl(): ContributionDetailsViewModel {
     private val mutableState = MutableStateFlow(ContributionDetailsUiState())
     override val state: StateFlow<ContributionDetailsUiState>
         get() = mutableState
+
+    override fun onConfirm() {
+        TODO("Not yet implemented")
+    }
 }

--- a/feature/funds/src/commonMain/kotlin/viewmodels/ContributionHistoryViewModel.kt
+++ b/feature/funds/src/commonMain/kotlin/viewmodels/ContributionHistoryViewModel.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 interface ContributionHistoryViewModel {
     val state: StateFlow<DonationHistoryUiState>
-    fun onViewFund(fundId: String)
+    fun onViewFund(fundId: Uuid)
 }
 
 data class DonationHistoryUiState(
@@ -14,7 +14,7 @@ data class DonationHistoryUiState(
 )
 
 data class DonationUiState(
-    val id: String,
+    val id: Uuid,
     val title: String,
     val description: String,
 )
@@ -23,7 +23,7 @@ class ContributionHistoryViewModelImpl(): ContributionHistoryViewModel {
     override val state: StateFlow<DonationHistoryUiState>
         get() = TODO("Not yet implemented")
 
-    override fun onViewFund(fundId: String) {
+    override fun onViewFund(fundId: Uuid) {
         TODO("Not yet implemented")
     }
 }

--- a/feature/funds/src/commonMain/kotlin/viewmodels/FundDetailsViewModel.kt
+++ b/feature/funds/src/commonMain/kotlin/viewmodels/FundDetailsViewModel.kt
@@ -20,7 +20,7 @@ interface FundDetailsViewModel: BaseViewModel {
 }
 
 class FundDetailsViewModelImpl(
-    private val navController: StackNavigationController<Route<String>, Any>,
+    private val navController: StackNavigationController,
     private val createFundUseCase: CreateFundUseCase,
 ): FundDetailsViewModel {
     private val mutableLoadingState = MutableStateFlow<LoadingState>(LoadingState.Complete)

--- a/feature/profiles/src/commonMain/kotlin/navigation/ProfileRouting.kt
+++ b/feature/profiles/src/commonMain/kotlin/navigation/ProfileRouting.kt
@@ -4,47 +4,57 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import org.koin.mp.KoinPlatform.getKoin
-import org.pointyware.painteddogs.core.navigation.LocationRootScope
-import org.pointyware.painteddogs.core.navigation.Route
-import org.pointyware.painteddogs.core.navigation.route
+import org.pointyware.painteddogs.core.entities.Uuid
+import org.pointyware.painteddogs.core.navigation.TypeRouterScope
+import org.pointyware.painteddogs.feature.funds.navigation.Funds
 import org.pointyware.painteddogs.feature.funds.ui.ContributionHistoryScreen
 import org.pointyware.painteddogs.feature.profiles.di.ProfileDependencies
 import org.pointyware.painteddogs.feature.profiles.ui.UserProfileView
 
-val profileRoute = route("users", "\$id")
-val profileFundsRoute = route("users", "\$id", "funds")
 
+data class Profile(val id: Uuid) {
+    inner class Funds
+    inner class Contributions
+}
 /**
  * Sets up all routes for profile navigation and defines navigation callbacks.
  */
 @Composable
-fun LocationRootScope<Route<String>, Any>.profileRouting(
+fun TypeRouterScope.profileRouting(
     onLogout: () -> Unit,
 ) {
     val di = remember { getKoin() }
     val profileDependencies = remember { di.get<ProfileDependencies>() }
 
     // a user needs to control how they appear to others
-    location(profileRoute) {
+    location(Profile::class) { navController, _ ->
         val viewModel = remember { profileDependencies.getProfileViewModel() }
         val mapper = remember { profileDependencies.getProfileUiStateMapper() }
         val state = viewModel.state.collectAsState()
         UserProfileView(
             state = mapper.map(state.value),
             onEditProfile = viewModel::onEditProfile,
-            onViewCollections = { userId -> it.navigateTo(route("users", userId.toString(), "funds")) },
-            onViewContributions = { userId -> it.navigateTo(route("users", userId.toString(), "contribs")) },
+            onViewCollections = { userId ->
+                val arg = Profile(id = userId).Funds()
+                navController.navigateTo(Profile.Funds::class, arg)
+            },
+            onViewContributions = { userId ->
+                val arg = Profile(id = userId).Contributions()
+                navController.navigateTo(Profile.Contributions::class, arg)
+            },
             onLogout = onLogout,
         )
     }
     // a user can see all their current and past collections
-    location(profileFundsRoute) {
+    location(Profile.Funds::class) { navController, _ ->
         val viewModel = remember { profileDependencies.getContributionHistoryViewModel() }
         val mapper = remember { profileDependencies.getContributionHistoryUiStateMapper()}
         val state = viewModel.state.collectAsState()
         ContributionHistoryScreen(
             state = mapper.map(state.value),
-            onViewFund = { fundId -> it.navigateTo(route("funds", fundId)) },
+            onViewFund = { fundId ->
+                val arg = Funds.FundDetails(fundId)
+                navController.navigateTo(Funds.FundDetails::class, arg) },
         )
     }
 }


### PR DESCRIPTION
Replace segment list routes with type "routes"

Swap locationroot for type router

remove extra type parameters

remove LocationRoot file in favor of type router

remove explicit type bounds

remove string list router

Add typed key routes to experiments

remove generic upperboudn

experiment with alternative routers

Enable k2 compiler

KSP 2.0.0 reportedly uses the k2 compiler but in test report it appears to be using jdk 1.9 (AS-embedded version)

Add readme thoughts

remove commented resources

replace home routes with constants

replace location routes with constants

Define route constants

update fab for location

temporarily disable bottom bar

realize static/variable segments

replace todo with uuid string

remove superfluous AuthenticatedUser.kt

explain disambiguation

Start creating login files

Extend User for login purposes

Add :feature:login dependency on :feature:profile

Add user type to profiles module

Add payments dependency to funds/rides submodules

add routes tests

add imagined interfaces in documentation

split remaining delimited strings

add routing todo

implement missing test fund repo methods

throw exception for unknown locations

remove GCloudService.kt

inject ktor client

provide http in :core:remote module

add ktor import

pass through ktor types for consumers of :core:remote

setup ktor-okhttp/cio remote clients

correct parameter name

Correct more collections names -> funds

replace repository injection with use case

Add loading state to view model and bind job result

Add update/delete facilities for cache/api

Fix outdated names

Add docs

reformat FundDetailsViewModel binding for readability

Fix outdated name

Fix old typing for nav controller

fix missing nav controller

observe view model for back navigation when contribution is created

Swap concatenated strings for string-routes

begin type-safe implementation of routes

Setup contribution info view model/ui binding

Setup contribution details view model/ui binding

Setup fund info view model/ui binding

Setup search view model/ui binding

replace funds routing callbacks with internal navigation invocation

replace profile routing callbacks with internal navigation invocation

replace home routing callbacks with internal navigation invocation

remove unused nav controller in location root scope

pass navController into content scopes

evenly distribute bottom bar

Align title to center

bind location string to title bar

Replace fab text with icon

Replace bottom bar text with icons

bind navigation state to back icon

Replace text with account and search icons

declare top app bar color tokens in comment

Add nav controller todo note

add routing doc

Fix string instead of uuid

inject and user profile ui state mapper instead of static object

pass user ids for nav routes

add home module to app module and profile home dependencies

make profile view scrollable

Remove redundant profileScreen

down-hoist onEditProfile

rely on composability of functions to prevent recalculating content graph

content graph is already minimal since it just constructs a map of composable functions which only execute when the matching location is set; although it would be nice to reduce since it could cause memory threshing

make location scope composable again

fix unused injected mapper

recalculate nav graph if controller or content definition change

add auth doc

move HomeUiState out to dedicated file

make location composable function

replace icons with text temporarily

* replacing with injected platform-bound resources

update test

add resources doc

complete desktopModule resources

remove github packages note

replace dummy data with view model state mapping

remove unused buttons

setup funds routing dependencies tasks

Create fund details view model to map actual state

Define base view model

Update generated import

Replace all wrong package ids

Fix package ids

Setup shared/platform resource bindings

Fix ambiguous ad module

Specify fab position

Move old "collections" files to funds module

move client ad objects to client module

move koin references to top of file

Add profile view models to dependencies and koin module

Add ContributionHistoryViewModelImpl

 Define home dependencies and koin module

replace confirmation callbacks

start replacement of fundsNavigation with FundsRouting

Convert navigation file to routing file

remove dependency groups

Hoist home routing navigation logic to nav root

Add :core:common module

remove base core/feature empty modules

Separate mapping logic from ui/view model bindings

organize profile types

Move home location mapping to HomeRouting file

 remove lifecycle koin

Update android imports

Fix padding values applied in wrong place

remove opt-in

swap vectors for pngs

fix wrong resource reference

make shared resources public

fix shared package name

update deprecated compiler options

ignore kotlin build output

Update ksp for kotlin 2.0

Add compose compiler plugin

remove unused resource references

Fix imports after moving tests

Add app-shared icons

document painted dogs theme

simplify injection by assuming null initial location

provide ProfileDependencies in profile module

remove unused actuals

correct resource naming/placement

Add tray icon drawables

Move "collections" tests into funds module

Enable multiplatform resources in desktop app

Add :feature:rides module

plan other top-level destinations

remove todo note

Move desktop main to kotlin source folder

remove :core:navigation module from feature:funds

Setup funds bindings

remember dependencies between compositions

Define ui/data coroutine scopes

Move app navigation groups out to feature modules

refactor di names

pass default dependencies to app

Add navigation dependencies to app container

Remove unnecessary mock impl

using mocks would be controlled by using a different top-level injection

Start funds navigation root

Add navigation dependencies to fund module

Add navController to navigation component

remember dependencies within app scope

Remove koin references

Start koin for desktop app

Setup main branches of dependency tree

Move :feature:payments:core definitions to parent module

include navigation module

Setup simple koin modules

Add test plans

introduce import

remove todo comment

Move HomeScreen to app-shared module

Add artifact registry plugin

defer github packages for artifact registry

Add Cloud Run project.toml

Comment undefined bindings

Remove todo doc

Describe fund user flow

Add :core:entities

rename routing files

Add missing import

Use environment variable for port for other running environments

Define MVP routes

Link app and core/feature koin modules

Migrate :feature:collections:* to :feature:funds

Start core modules

Add PDApplication to offload koin app setup

remove unused imports

Add server mock responses

remove todo

Fix app name and colors

Add ktor plugin

Setup api publishing artifact

Create api entry point and move ads/analytics specifics to server submodules

Move :api:* modules to server submodules

Setup ktor server dependencies for ads/analytics

Add docs and user info

Create simple analytics interactor

Setup koin

Start AbstractRepository

Enable compose multiplatform resources

* Add Test-Ad.svg

Add AppModule dependencies

Fix missing escape slash

Fix current location not observed

Implement stack navigation controller

Fix missing coroutines dependency

Mock out make contribution view

Reuse FundDetailsView in screen

Remove request payout view

Mock profile view

Fix dependency string

Add platform-specific coroutines

Implement naive screens

Implement naive ContributionHistoryScreen

Implement naive FundDetailsScreen

Mock out profile screen

Implement naive navController support

Move LocationRoot to :core:navigation module

I have no interest in decoupling from compose like decompose – just in a multiplatform implementation similar to the experimental compose-navigation

Implement home screen

Move FundCreation/SearchView(s) to :feature:collections module

add todo notes

conceal state scope

conceal _currentFrame and move to alias property

pass app content modifier to location root

Add required dark theme parameter

Add contributions history location

Add Screens

* Collection
  * Details
  * History
  * Info
  * Search
* Contribution
  * Details
  * History
  * Info
* Home
* Profile

Add Views

* FundCreationView
* FundDetailView
* MakeContributionView
* RequestPayoutView
* UserProfileView

Add Components

* FundProgressBar
* SearchTextField

Rearrange imports

Setup convention plugins in project root

Document nav expectations

Use Painted Dogs App entry point in android and desktop apps

Add maven local repositories

Add jvm target to :feature:login module

Create LocationRoot composable to :core:navigation:compose module

Add space, navigation controller, and arguments files

Add :core:navigation:compose module

Add gradle plugin compile dependencies

Fix missing module names

Create FlowExt in :core:entities module

Create KmpTargetsConventionPlugin

* start blank KoinDependencyInjectionConventionPlugin

Prepare :feature:collections to take submodules

Move PrivacySetting to root of src/kotlin

Setup shared app dependencies

Add app-shared module

Enable kotlinx coroutines

Add :core:entities to :core:ui

Move previews to :core:ui root package

Add :core:navigation readmes

Define tan color

use tan for launcher background

Change tan value

Create .aiexclude file

Add launcher assets

Create theme date formatter

* create composition local
* provide naive toString implementation

Clarify intent of core ui

rename screens to views; thinking in terms of screens requires consideration for the device size, which increases complexity for a cross platform implementation (or severely limits what is usable), while reducing the scope to views allows each platform to compose views into device-specific screen arrangements

Add :core:view-models module readme

Use main program to preview date selector

Move date selector row into components package

Add preview borders

Add :core:ui module readme

Replace dummy text with date selector row component

Replace compose plugin dependencies with explicit android version catalog entry

Replace removed theme with app theme

Add compose android dependencies

Remove application theme

Add theme preview with simple components

Create preview in fund creation view file

Add android-explicit material3 dependency

Add :core:navigation module

replace object todo impl with test view model

Remove unused job container

Add naive coroutine scope

Remove unused modifier

Add android compose test dependencies

Attempt to reuse state and callbacks across multiple previews

Add desktop previews composable

regularize ui dependencies

Move DateSelectorRow into common ui module

Fix package identifier

Define painted dogs theme primitives

Remove unused composable

Add popular device size preview annotation

Add androidx preview dependencies

Add date selector row preview